### PR TITLE
Cf friends main display

### DIFF
--- a/src/scripts/friends/eventListeners.js
+++ b/src/scripts/friends/eventListeners.js
@@ -1,0 +1,8 @@
+import { displayMainFriendsList } from "./friendsDisplay"
+
+// display friends list in main when friends side container is clicked
+export const clickFriendsSideContainer = (friendsList) => {
+    document.querySelector("#friends-container").addEventListener("click", event => {
+        displayMainFriendsList(friendsList)
+    })
+}

--- a/src/scripts/friends/friends.js
+++ b/src/scripts/friends/friends.js
@@ -1,11 +1,15 @@
 import { displaySideFriendsList, displayMainFriendsList } from "./friendsDisplay.js"
+import { clickFriendsSideContainer } from "./eventListeners.js"
 
 // container for all "friends" functionality
 export const displayFriends = () => {
     const friendsList = JSON.parse(window.sessionStorage.getItem("friends"))
     displaySideFriendsList(friendsList)
-    displayMainFriendsList(friendsList)
+    clickFriendsSideContainer(friendsList)
 
+    // adds scroll bar to friends side container and main when populated
+    const friendsContentMain = document.getElementById("main-container")
+    friendsContentMain.scrollTop = friendsContentMain.scrollHeight 
     const friendsContent = document.getElementById("friends-content")
     friendsContent.scrollTop = friendsContent.scrollHeight
 }

--- a/src/scripts/friends/friends.js
+++ b/src/scripts/friends/friends.js
@@ -1,7 +1,11 @@
-import { displaySideFriendsList } from "./friendsDisplay.js"
+import { displaySideFriendsList, displayMainFriendsList } from "./friendsDisplay.js"
 
 // container for all "friends" functionality
 export const displayFriends = () => {
     const friendsList = JSON.parse(window.sessionStorage.getItem("friends"))
     displaySideFriendsList(friendsList)
+    displayMainFriendsList(friendsList)
+
+    const friendsContent = document.getElementById("friends-content")
+    friendsContent.scrollTop = friendsContent.scrollHeight
 }

--- a/src/scripts/friends/friendsDisplay.js
+++ b/src/scripts/friends/friendsDisplay.js
@@ -1,4 +1,4 @@
-import { buildSideFriendHTML } from "./friendsHTML.js"
+import { buildSideFriendHTML, buildMainFriendHTML } from "./friendsHTML.js"
 
 // displays friend cards in side container
 export const displaySideFriendsList = friendsArray => {
@@ -7,4 +7,13 @@ export const displaySideFriendsList = friendsArray => {
         friendsListHTML += buildSideFriendHTML(friend)
     }
     document.querySelector("#friends-content").innerHTML = friendsListHTML
+}
+
+// displays friend cards in side container
+export const displayMainFriendsList = friendsArray => {
+    let friendsListHTML = ""
+    for (let friend of friendsArray) {
+        friendsListHTML += buildMainFriendHTML(friend)
+    }
+    document.querySelector("#main-content").innerHTML = friendsListHTML
 }

--- a/src/scripts/friends/friendsDisplay.js
+++ b/src/scripts/friends/friendsDisplay.js
@@ -11,9 +11,9 @@ export const displaySideFriendsList = friendsArray => {
 
 // displays friend cards in side container
 export const displayMainFriendsList = friendsArray => {
-    let friendsListHTML = ""
+    let friendsListHTML = "<h1>Friends List</h1>"
     for (let friend of friendsArray) {
         friendsListHTML += buildMainFriendHTML(friend)
     }
-    document.querySelector("#main-content").innerHTML = friendsListHTML
+    document.querySelector("#main-container").innerHTML = friendsListHTML
 }

--- a/src/scripts/friends/friendsHTML.js
+++ b/src/scripts/friends/friendsHTML.js
@@ -7,3 +7,16 @@ export const buildSideFriendHTML = friendObj => {
     </div>
     `
 }
+
+// build individual friend card for side container
+export const buildMainFriendHTML = friendObj => {
+    return `
+    <div class="friend-card">
+        <div class="friend-inline-el">${friendObj.user.fullName}</div>
+        <div class="remove-button-container">
+            <span class="friend-inline-el">${friendObj.user.email}</span>
+            <button class="remove-button btn btn-sm btn-danger">X</button>
+        </div>
+    </div>
+    `
+}

--- a/src/scripts/friends/friendsHTML.js
+++ b/src/scripts/friends/friendsHTML.js
@@ -8,7 +8,7 @@ export const buildSideFriendHTML = friendObj => {
     `
 }
 
-// build individual friend card for side container
+// build individual friend card for main container
 export const buildMainFriendHTML = friendObj => {
     return `
     <div class="friend-card">

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -47,3 +47,10 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+.remove-button {
+  position: relative;
+  top: -4.5px;
+  left: 2px;
+  float: right;
+}


### PR DESCRIPTION
# Description

- added scroll bar to friends side container, but I had to add 5 friends (total of 7 friends) to user 2 in my local json database to be able to test this
- added click event to friends side container that displays friends list in main with delete button (delete button not functional yet)

Fixes # (issue)
 
## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Testing Instructions

1. "git fetch --all"
2. "git checkout cf-friends-main-display"
3. "npm start"
4. please make sure that main displays the friends list when the friends side container is clicked on
5. also please check that clicking on other side containers does not break functionality of friends list display in main

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works